### PR TITLE
Add ability for users to mark question as done

### DIFF
--- a/.wakatime-project
+++ b/.wakatime-project
@@ -1,0 +1,1 @@
+Purple Song 92

--- a/.wakatime-project
+++ b/.wakatime-project
@@ -1,1 +1,0 @@
-Purple Song 92

--- a/events/mark_resolved.py
+++ b/events/mark_resolved.py
@@ -16,12 +16,13 @@ async def delete_task(ts: str, client: AsyncWebClient):
         )
 
 
+
 async def handle_mark_resolved(
     ts,
     resolver_id,
     client: AsyncWebClient,
     message: bool = True,
-    custom_response: str | None = None,
+    custom_response: str | None = None
 ):
     # channel_name = await client.conversations_info(channel=env.slack_support_channel)
     # if not channel_name["channel"]["is_channel"]:

--- a/events/on_message.py
+++ b/events/on_message.py
@@ -59,10 +59,11 @@ async def handle_new_support_response(body: Dict[str, Any], client: AsyncWebClie
     req = env.airtable.get_request(body["event"]["thread_ts"])
     if not req:
         return
-
-    if req["fields"]["status"] == "resolved":
-        return
-
+    try:
+        if req["fields"]["status"] == "resolved":
+            return
+    except KeyError:
+        pass
     req_msg = await client.conversations_history(
         channel=env.slack_request_channel,
         latest=req["fields"]["internal_thread"],

--- a/events/on_reaction.py
+++ b/events/on_reaction.py
@@ -5,7 +5,6 @@ from utils.env import env
 
 
 async def handle_reaction(body: Dict[str, Any], client: AsyncWebClient):
-    print(body)
     if body["event"]["reaction"] == "white_check_mark":
         help_event = env.airtable.get_request(pub_thread_ts=body["event"]["item"]["ts"])
         try:
@@ -23,11 +22,3 @@ async def handle_reaction(body: Dict[str, Any], client: AsyncWebClient):
             OG_slack_asker_slackid = None
         if OG_slack_asker_slackid == resolver_id:
             await handle_mark_resolved(ts, resolver_id, client)
-        else:
-            await client.chat_postMessage(
-            channel=env.slack_support_channel,
-            thread_ts=body["event"]["item"]["ts"],
-            text=f"Hey <@{OG_slack_asker_slackid}>, <@{resolver_id}> belives they have resolved this issue. If you believe this issue is resolved, please react with :white_check_mark: to confirm on the original thread (the one with the :thinking_face:).",
-            unfurl_links=True,
-            unfurl_media=True
-        )

--- a/events/on_reaction.py
+++ b/events/on_reaction.py
@@ -1,0 +1,33 @@
+from slack_sdk.web.async_client import AsyncWebClient
+from events.mark_resolved import handle_mark_resolved
+from typing import Dict, Any
+from utils.env import env
+
+
+async def handle_reaction(body: Dict[str, Any], client: AsyncWebClient):
+    print(body)
+    if body["event"]["reaction"] == "white_check_mark":
+        help_event = env.airtable.get_request(pub_thread_ts=body["event"]["item"]["ts"])
+        try:
+            if help_event["fields"]["status"] == "resolved":
+                return
+        except KeyError:
+            pass
+        ts = help_event["fields"]["internal_thread"]
+        resolver_id = body["event"]["user"]
+        OG_slack_asker_airtable_id = help_event["fields"]["person"][0]
+        OG_slack_asker = env.airtable.get_person_by_id(OG_slack_asker_airtable_id)
+        if OG_slack_asker:
+            OG_slack_asker_slackid = OG_slack_asker["fields"]["slack_id"]
+        else:
+            OG_slack_asker_slackid = None
+        if OG_slack_asker_slackid == resolver_id:
+            await handle_mark_resolved(ts, resolver_id, client)
+        else:
+            await client.chat_postMessage(
+            channel=env.slack_support_channel,
+            thread_ts=body["event"]["item"]["ts"],
+            text=f"Hey <@{OG_slack_asker_slackid}>, <@{resolver_id}> belives they have resolved this issue. If you believe this issue is resolved, please react with :white_check_mark: to confirm on the original thread (the one with the :thinking_face:).",
+            unfurl_links=True,
+            unfurl_media=True
+        )

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from threading import Thread
 from typing import Dict, Any
 
 from events.macros import create_macro, handle_execute_macro
+from events.on_reaction import handle_reaction
 from utils.info import get_user_info
 from utils.env import env
 from utils.queue import process_queue
@@ -38,11 +39,13 @@ async def ping(request):
         "message": "App is running"
     })
 
-
 @app.event("message")
 async def handle_message_events(body: Dict[str, Any], client: AsyncWebClient, say):
     await handle_message(body, client, say)
 
+@app.event("reaction_added")
+async def handle_reaction_added_events(body: Dict[str, Any], client: AsyncWebClient):
+    await handle_reaction(body, client)
 
 @app.action("mark-resolved")
 async def handle_mark_resolved_button(

--- a/utils/airtable.py
+++ b/utils/airtable.py
@@ -44,6 +44,10 @@ class AirtableManager:
     def get_person(self, user_id: str) -> RecordDict | None:
         user = self.people_table.first(formula=f'{{slack_id}} = "{user_id}"')
         return user
+    def get_person_by_id(self, id: str) -> RecordDict | None:
+        """Gets person by their Airtable ID"""
+        user = self.people_table.get(id)
+        return user
     
     def get_macros(self, user_id: str) -> List[Macro]:
         macros = self.macro_table.first(formula=f'{{slack_id}} = "{user_id}"')
@@ -146,6 +150,7 @@ class AirtableManager:
         if not resolver_item:
             return
         id = resolver_item.get("id")
+
         req = self.get_request(priv_thread_ts=priv_thread_ts)
         if not req:
             return


### PR DESCRIPTION
If the asker reacts with ✅, then it will get marked as done and removed from the support channel.
If someone else reacts, then it will ask the user if they want to close it.
Added a try catch for handling blank "status" fields (should never happen)
